### PR TITLE
Fix benchmark code to empty cache in setup phase

### DIFF
--- a/Chapter06/MemoizationPattern/1_fib.jl
+++ b/Chapter06/MemoizationPattern/1_fib.jl
@@ -58,8 +58,9 @@ function fib(n)
     end
 end
 
+# Benchmark performance. Make sure cache is emptied at each
 #=
-julia> @btime fib(40)
-  33.516 ns (0 allocations: 0 bytes)
+julia> @btime fib(40) setup=(empty!(fib_cache))
+  38.731 ns (0 allocations: 0 bytes)
 102334155
 =#


### PR DESCRIPTION
Errata image on page 249.

<img width="716" alt="Screen Shot 2020-09-12 at 5 04 22 PM" src="https://user-images.githubusercontent.com/1159782/93007143-19430980-f51a-11ea-9982-5fb58fc5ed01.png">
