### PR TITLE
Update abstract_types.jl

### DIFF
--- a/Chapter02/abstract_types.jl
+++ b/Chapter02/abstract_types.jl
@@ -22,7 +22,7 @@ describe(e::Property) = "Physical property"
 
 Returns the location of the property as a tuple of (latitude, longitude).
 """
-location(p::Property) = error("Location is not defined in the concrete type")
+location(p::Property) = error("Location is not defined in the abstract type")
 
 # an empty function
 """


### PR DESCRIPTION
fix typo.

Edit:
realized I read it in a different way, I guess we could say:
```
location(p::T) where T<:Property = error("not implemented for concrete type $T")
```

but yeah this is too early to introduce this I guess